### PR TITLE
Add endpoint for listing arrivals

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,10 +14,10 @@ steps:
     args: 
     - functions
     - deploy
-    - 'ingest'
+    - 'arrivals'
     - --trigger-http
     - --runtime=go113
-    - --entry-point=Ingest
+    - --entry-point=Arrivals
     - --region=us-east1
     - --env-vars-file=env.yaml
     - --allow-unauthenticated

--- a/fns/Makefile
+++ b/fns/Makefile
@@ -4,7 +4,7 @@
 #	GO111MODULE=on go mod init
 
 deploy:
-	gcloud functions deploy ingest --entry-point Ingest --runtime go113 --trigger-http --env-vars-file env.yaml --region us-east1 --allow-unauthenticated --source .
+	gcloud functions deploy arrivals --entry-point Arrivals --runtime go113 --trigger-http --env-vars-file env.yaml --region us-east1 --allow-unauthenticated --source .
 
 deployQueryByPort:
 	gcloud functions deploy byPortOfEntry --entry-point FindByPortOfEntry --runtime go113 --trigger-http --env-vars-file env.yaml --region us-east1--allow-unauthenticated --source .

--- a/fns/domain/types_test.go
+++ b/fns/domain/types_test.go
@@ -1,18 +1,13 @@
-package persistence
+package domain_test
 
 import (
-	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	"bz.epi.covid.screen/arrivals/domain"
 )
 
-func TestFirestoreClient_UpsertArrival(t *testing.T) {
-	client := CreateClient(context.Background(), "epi-belize")
-	defer client.Close()
-
+func TestHydrateCompanions(t *testing.T) {
 	dateLayout := "2006-01-02"
 	dob, _ := time.Parse(dateLayout, "1977-04-15")
 	dateScreened, _ := time.Parse(dateLayout, "2020-05-24")
@@ -111,70 +106,11 @@ func TestFirestoreClient_UpsertArrival(t *testing.T) {
 	}
 
 	arrivals := domain.HydrateCompanions([]domain.NewArrival{newArrival, companion})
-	err := client.UpsertArrival("port-of-entry-screening", arrivals)
 
-	if err != nil {
-		t.Fatalf("UpsertArrival() failed. want nil got %v", err)
+	first := arrivals[0]
+	second := arrivals[1]
+
+	if first.TravellingCompanions[0].FirstName != second.PersonalInfo.FirstName {
+		t.Errorf("names did not match")
 	}
-}
-
-func TestFirestoreClient_FindByName(t *testing.T) {
-	client := CreateClient(context.Background(), "epi-belize")
-	defer client.Close()
-
-	res, err := client.FindByLastName("port-of-entry-screening", "Guerra")
-	if err != nil {
-		t.Fatalf("FindByLastName() error: %v", err)
-	}
-
-	if len(res) == 0 {
-		t.Fatalf("FindByLastName() result size: got: %d, want: 1", len(res))
-	}
-
-	personalInfo := res[0].PersonalInfo
-
-	if personalInfo.FirstName != "Roberto" && personalInfo.LastName != "Guerra" {
-		t.Errorf("FindByLastName() got: %s, want: Roberto Guerra",
-			fmt.Sprintf("%s %s", personalInfo.FirstName, personalInfo.LastName))
-	}
-
-	dob := personalInfo.Dob.Format("2006-01-02")
-	if dob != "1977-04-15" {
-		t.Errorf("Could not parse dob, got: %s, want: %s", dob, "1977-04-15")
-	}
-
-	t.Logf("Results: %v", res)
-}
-
-func TestFirestoreClient_FindByScreeningLocation(t *testing.T) {
-	client := CreateClient(context.Background(), "epi-belize")
-	defer client.Close()
-
-	res, err := client.FindByPortOfEntry("port-of-entry-screening", "pgia")
-	if err != nil {
-		t.Fatalf("FindByPortOfEntry error: %v", err)
-	}
-
-	if len(res) == 0 {
-		t.Fatalf("FindByPortOfEntry got: %d, want: 1", len(res))
-	}
-
-	portOfEntry := res[0].ArrivalInfo.PortOfEntry
-
-	if portOfEntry != "pgia" {
-		t.Errorf("FindByPorfOfEntry got: %s, want: pgia", portOfEntry)
-	}
-}
-
-func TestPaginateQuery(t *testing.T) {
-	client := CreateClient(context.Background(), "epi-belize")
-	defer client.Close()
-
-	arrivals, err := client.List("port-of-entry-screening", "2020-05-23%23Mau-Xhi%2399119911")
-
-	if err != nil {
-		t.Fatalf("error listing arrivals: %+v", err)
-	}
-
-	t.Logf("Arrivals: %+v", arrivals)
 }

--- a/fns/persistence/firestore.go
+++ b/fns/persistence/firestore.go
@@ -121,3 +121,29 @@ func (c FirestoreClient) FindByPortOfEntry(col, loc string) ([]domain.Arrival, e
 	}
 	return arrivals, nil
 }
+
+// List retrieves a list of records ordered in descending order by their id.
+// The `id` is the record to start after. It is useful for paginating results.
+func (c FirestoreClient) List(col, id string) ([]domain.Arrival, error) {
+	arrivals := []domain.Arrival{}
+	it := c.client.Collection(col).
+		OrderBy("Id", firestore.Desc).
+		StartAfter(id).
+		Limit(25).
+		Documents(c.ctx)
+
+	for {
+		doc, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var a domain.Arrival
+		doc.DataTo(&a)
+
+		arrivals = append(arrivals, a)
+	}
+	return arrivals, nil
+}


### PR DESCRIPTION
Add `next_page` to arrivals listing response to facilitate pagination.

It is important that the `Id` has a date prefix in the form:
`YYYY-MM-DD`, because we order by the `Id` and we use it as a
cursor when paginating through results.